### PR TITLE
Add retention policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+---
+repos:
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v2.2.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        args: ["--config", ".commitlint.config.js"]
+        additional_dependencies: ['@commitlint/config-conventional']
+  - repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+      - id: black
+        args:
+          - --line-length=90
+          - --include='didweb'
+        stages: [commit]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.0
+    hooks:
+      - id: flake8
+        args:
+          - "--max-line-length=90"
+          - "--max-complexity=18"
+        stages: [commit]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 # ACA-Python DID Web plugin
 
+## Developing
+
+First-time initialization of the python environment:
+
+```bash
+poetry install
+pre-commit install
+```
+
+You're all set !
+
+To run aca-py with the plugin, include it in your config:
+
+```yaml
+plugin:
+  - didweb
+```
+
+and run aca-py from the poetry environment:
+```bash
+poetry env
+aca-py ....
+```
+
 ## Creating a did:web
 
 ```bash

--- a/didweb/__init__.py
+++ b/didweb/__init__.py
@@ -6,7 +6,7 @@ WEB = DIDMethod(
     name="web",
     key_types=[ED25519],
     rotation=True,
-    holder_defined_did=HolderDefinedDid.REQUIRED
+    holder_defined_did=HolderDefinedDid.REQUIRED,
 )
 
 

--- a/didweb/didweb_manager.py
+++ b/didweb/didweb_manager.py
@@ -1,65 +1,82 @@
 import base64
-from typing import Mapping, Iterable, Tuple, Collection, List
+from dataclasses import dataclass
+from typing import Iterable, Tuple, List
 
 import base58
 from aries_cloudagent.storage.base import BaseStorage
-from aries_cloudagent.storage.record import StorageRecord
 from aries_cloudagent.wallet.base import BaseWallet
 from aries_cloudagent.wallet.did_info import DIDInfo
 
 from pydid import DIDDocumentBuilder, DIDUrl
 from pydid.verification_method import JsonWebKey2020, VerificationMethod
 
-PREVIOUS_PUBLIC_KEY_RECORD_TYPE = "PREVIOUS_PUBLIC_KEY"
+from didweb.retention import AskarStorageStrategy, NumberOfKeysStrategy
 
 
 class UnknownDIDException(Exception):
     """When trying to operate on an unknown DID."""
 
 
+@dataclass
+class RecallStrategyConfig:
+    number_of_keys: int = 0
+
+
 class DIDWebManager:
-    def __init__(self, wallet: BaseWallet, storage: BaseStorage):
+    def __init__(
+        self,
+        wallet: BaseWallet,
+        storage: BaseStorage,
+        recall_strategy_config: RecallStrategyConfig = None,
+    ):
         self.__wallet = wallet
         self.__storage = storage
+        self.__storage_strategy = AskarStorageStrategy(self.__storage)
+        self.__recall_strategy = (
+            NumberOfKeysStrategy(
+                self.__storage_strategy, recall_strategy_config.number_of_keys
+            )
+            if recall_strategy_config
+            else NumberOfKeysStrategy(self.__storage_strategy, 0)
+        )
 
     async def get_diddoc(self, did: str):
+        """
+        Generate a DIDDocument for a given DID
+        :param did:
+        :return: a w3c compliant DID Document
+        """
+
         # fetch did with current key
         did_info, signing_key_b64 = await self._get_did_and_signing_key(did)
         if not did_info:
             raise UnknownDIDException()
 
-        # Also retrieve n previous keys
-        previous_keys = await self._previous_keys(did)
+        # Also retrieve n previous keys and build complete key list
+        previous_keys = await self.__recall_strategy.previous_keys(did)
+        keys_with_indices = [
+            (await self.__storage_strategy.current_index(did), signing_key_b64)
+        ]
+        keys_with_indices.extend(
+            [(previous_key.index, previous_key.key) for previous_key in previous_keys]
+        )
 
         # Build diddoc
         did_doc_builder = DIDDocumentBuilder(did, controller=[did])
-        keys_with_indices = _keys_and_indices(previous_keys, signing_key_b64)
 
         verification_methods = _build_verification_methods(did, keys_with_indices)
         did_doc_builder.verification_method.methods.extend(verification_methods)
 
-        # reference the keys in the authentication and assertion
+        # reference the keys in the other sections
         all_key_references = _build_key_references(did, keys_with_indices)
         did_doc_builder.authentication.methods.extend(all_key_references)
-        did_doc_builder.assertion_method.methods.extend(all_key_references)
 
         return did_doc_builder.build()
 
     async def rotate_key(self, did: str):
+        # Safe keep the old key
         did_info, signing_key_b64 = await self._get_did_and_signing_key(did)
-
-        previous_keys = await self._previous_keys(did)
-        index = _current_index(previous_keys)
-
-        # Store current key
-        # record: (type, value, tags, id)
-        current_key_record = StorageRecord(
-            PREVIOUS_PUBLIC_KEY_RECORD_TYPE,
-            signing_key_b64,
-            {"did": did, "index": str(index)},
-            f"{did_info.did}{index}"
-        )
-        await self.__storage.add_record(current_key_record)
+        await self.__storage_strategy.store_old_key(did, signing_key_b64)
 
         # Rotate key in wallet
         await self.__wallet.rotate_did_keypair_start(did)
@@ -74,23 +91,10 @@ class DIDWebManager:
 
         return did_info, signing_key_b64
 
-    async def _previous_keys(self, did) -> Mapping[int, bytes]:
-        previous_keys = await self.__storage.find_all_records(PREVIOUS_PUBLIC_KEY_RECORD_TYPE, {"did": did})
-        return {int(key.tags.get("index")): key.value for key in previous_keys}
 
-
-def _keys_and_indices(previous_keys: Mapping[int, bytes], current_key: bytes) -> Iterable[Tuple[int, bytes]]:
-    keys = [(index, verkey) for index, verkey in previous_keys.items()]
-    keys.append((_current_index(previous_keys.keys()), current_key))
-
-    return keys
-
-
-def _current_index(indices: Collection[int]) -> int:
-    return max(indices) + 1 if len(indices) > 0 else 1
-
-
-def _build_verification_methods(did: str, keys_with_indices: Iterable[Tuple[int, bytes]]) -> List[VerificationMethod]:
+def _build_verification_methods(
+    did: str, keys_with_indices: Iterable[Tuple[int, bytes]]
+) -> List[VerificationMethod]:
     return [
         JsonWebKey2020(
             id=f"{did}#key-{index}",
@@ -98,18 +102,16 @@ def _build_verification_methods(did: str, keys_with_indices: Iterable[Tuple[int,
             controller=did,
             public_key_jwk={
                 "kty": "OKP",
-                "crv": "Ed25519",  # TODO: remove hard-coding if we want to support more key types
-                "x": signing_key
-            }
+                # TODO: remove hard-coding if we want to support more key types
+                "crv": "Ed25519",
+                "x": signing_key,
+            },
         )
-        for index, signing_key
-        in keys_with_indices
+        for index, signing_key in keys_with_indices
     ]
 
 
-def _build_key_references(did: str, keys_with_indices: Iterable[Tuple[int, bytes]]) -> List[DIDUrl]:
-    return [
-        DIDUrl(f"{did}#key-{index}")
-        for index, _
-        in keys_with_indices
-    ]
+def _build_key_references(
+    did: str, keys_with_indices: Iterable[Tuple[int, bytes]]
+) -> List[DIDUrl]:
+    return [DIDUrl(f"{did}#key-{index}") for index, _ in keys_with_indices]

--- a/didweb/retention/__init__.py
+++ b/didweb/retention/__init__.py
@@ -1,0 +1,13 @@
+from .previous_key import PreviousKey
+from .recall_strategy import NumberOfKeysStrategy, RecallStrategy, RecallStrategyConfig
+from .storage_strategy import StorageStrategy, AskarStorageStrategy, NoStorageStrategy
+
+__all__ = [
+    "AskarStorageStrategy",
+    "NoStorageStrategy",
+    "StorageStrategy",
+    "NumberOfKeysStrategy",
+    "RecallStrategy",
+    "RecallStrategyConfig",
+    "PreviousKey",
+]

--- a/didweb/retention/previous_key.py
+++ b/didweb/retention/previous_key.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PreviousKey:
+    index: int
+    key: bytes

--- a/didweb/retention/recall_strategy.py
+++ b/didweb/retention/recall_strategy.py
@@ -1,0 +1,37 @@
+import abc
+import logging
+from dataclasses import dataclass
+
+from .storage_strategy import StorageStrategy
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RecallStrategyConfig:
+    number_of_keys: int
+
+
+class RecallStrategy(abc.ABC):
+    async def previous_keys(self, did: str):
+        """Return previous keys based on a set strategy"""
+
+
+class NumberOfKeysStrategy(RecallStrategy):
+    def __init__(self, storage_strategy: StorageStrategy, previous_keys: int = 0):
+        self.__storage_strategy = storage_strategy
+        self.__previous_keys = previous_keys
+
+    async def previous_keys(self, did: str):
+        all_previous_keys = await self.__storage_strategy.stored_keys(did)
+
+        reversed_previous_keys = sorted(
+            all_previous_keys, key=lambda previous_key: previous_key.index, reverse=True
+        )
+
+        logging.info(
+            "Returning %s previous keys out of %s entries",
+            self.__previous_keys,
+            len(reversed_previous_keys),
+        )
+        return reversed_previous_keys[: self.__previous_keys]

--- a/didweb/retention/storage_strategy.py
+++ b/didweb/retention/storage_strategy.py
@@ -1,0 +1,85 @@
+import abc
+import logging
+from typing import List
+
+from aries_cloudagent.storage.base import BaseStorage
+from aries_cloudagent.storage.record import StorageRecord
+
+from .previous_key import PreviousKey
+
+
+PREVIOUS_PUBLIC_KEY_RECORD_TYPE = "PREVIOUS_PUBLIC_KEY"
+logger = logging.getLogger(__name__)
+
+
+class StorageStrategy(abc.ABC):
+    async def stored_keys(self, did: str) -> List[PreviousKey]:
+        """retrieve all previous keys valid for the current strategy"""
+
+    async def store_old_key(self, did: str, signing_key: bytes):
+        """Store a key as a "previous" key."""
+
+    async def current_index(self, did: str) -> int:
+        """
+        Return the index for the currently in-use key based on the key history.
+        :param did:
+        :return:
+        """
+
+
+class AskarStorageStrategy(StorageStrategy):
+    def __init__(self, storage: BaseStorage):
+        """
+        :param storage:
+        """
+        self.__storage = storage
+
+    async def stored_keys(self, did) -> List[PreviousKey]:
+        previous_keys = await self.__storage.find_all_records(
+            PREVIOUS_PUBLIC_KEY_RECORD_TYPE, {"did": did}
+        )
+
+        return [
+            PreviousKey(int(key.tags.get("index")), key.value) for key in previous_keys
+        ]
+
+    async def store_old_key(self, did: str, signing_key: bytes):
+        """
+        :param did: DID for which the key is being safe-kept
+        :param signing_key: base 64 representation of the DID's signing key
+        :return:
+        """
+        # Store current key
+        # record: (type, value, tags, id)
+        index = await self.current_index(did)
+        logger.info("Storing key %s with index %s for did %s", did, index, signing_key)
+
+        current_key_record = StorageRecord(
+            PREVIOUS_PUBLIC_KEY_RECORD_TYPE,
+            signing_key,
+            {"did": did, "index": str(index)},
+            f"{did}#{index}",
+        )
+        await self.__storage.add_record(current_key_record)
+
+    async def current_index(self, did: str) -> int:
+        previous_keys = await self.stored_keys(did)
+
+        if previous_keys is None:
+            logger.error("Previous keys: %s", previous_keys)
+            raise ValueError("Provide a did or a list of previous keys")
+
+        indices = [key.index for key in previous_keys]
+        return max(indices) + 1 if len(previous_keys) > 0 else 1
+
+
+class NoStorageStrategy(StorageStrategy):
+    async def stored_keys(self, did: str) -> List[PreviousKey]:
+        """retrieve all previous keys valid for the current strategy"""
+        return list()
+
+    async def current_index(self, did: str) -> int:
+        """
+        Return the index for the currently in-use key based on the key history.
+        """
+        return 1

--- a/didweb/routes/__init__.py
+++ b/didweb/routes/__init__.py
@@ -30,4 +30,4 @@ def post_process_routes(app: web.Application):
     )
 
 
-__all__ = ['register', 'post_process_routes']
+__all__ = ["register", "post_process_routes"]

--- a/didweb/routes/rotate_key.py
+++ b/didweb/routes/rotate_key.py
@@ -11,9 +11,7 @@ from .openapi_config import OPENAPI_TAG
 from .schemas import DIDWebSchema
 
 
-@docs(
-    tags=[OPENAPI_TAG], summary="Rotate keys for specified did:web, return new DIDDoc"
-)
+@docs(tags=[OPENAPI_TAG], summary="Rotate keys for specified did:web, return new DIDDoc")
 @querystring_schema(DIDWebSchema())
 async def rotate_key(request: web.Request):
     did = request.query.get("did")
@@ -24,11 +22,10 @@ async def rotate_key(request: web.Request):
 
     async with context.profile.transaction() as transaction:
         manager = DIDWebManager(
-            transaction.inject(BaseWallet),
-            transaction.inject(BaseStorage)
+            transaction.inject(BaseWallet), transaction.inject(BaseStorage)
         )
 
         new_diddoc = await manager.rotate_key(did)
-        transaction.commit()
+        await transaction.commit()
 
     return web.Response(text=new_diddoc.to_json())

--- a/didweb/routes/schemas.py
+++ b/didweb/routes/schemas.py
@@ -1,6 +1,7 @@
 import re
 
 from aries_cloudagent.messaging.models.openapi import OpenAPISchema
+from aries_cloudagent.messaging.valid import GENERIC_DID
 from marshmallow import fields
 from marshmallow.validate import Regexp
 
@@ -9,7 +10,7 @@ class WebDID(Regexp):
     """Validate value against web DID."""
 
     EXAMPLE = "did:web:mydoma.in:some:weird:path"
-    PATTERN = re.compile(rf"^(did:web:)?[a-z]+\.[a-z]+(%3A[0-9]+)*(:[a-z]+)*$")
+    PATTERN = re.compile(r"^(did:web:)?[a-z]+\.[a-z]+(%3A[0-9]+)*(:[a-z]+)*$")
 
     def __init__(self):
         """Initializer."""
@@ -23,23 +24,24 @@ class WebDID(Regexp):
 WEB_DID = {"validate": WebDID(), "example": WebDID.EXAMPLE}
 
 
-class DIDWebSchema(OpenAPISchema):
-    """
-    """
+class KeyRetentionConfigSchema(OpenAPISchema):
+    """ """
 
-    did = fields.Str(
-        required=True,
-        **WEB_DID
-    )
+    number_of_keys = fields.Int(required=True)
+
+
+class DIDWebSchema(OpenAPISchema):
+    """ """
+
+    did = fields.Str(required=True, **GENERIC_DID)
+
+
+class GetDIDDocSchema(OpenAPISchema):
+    did = fields.Str(required=True, **GENERIC_DID)
+    number_of_keys = fields.Int(required=False)
+
 
 class DIDQueryStringSchema(OpenAPISchema):
     """Parameters and validators for set public DID request query string."""
 
-    did = fields.Str(description="DID of interest", required=True, **WEB_DID)
-
-
-class DIDWebDIDDocSchema(OpenAPISchema):
-    """
-    """
-
-    very = fields.Str(required=True, default="nice")
+    did = fields.Str(description="DID of interest", required=True, **GENERIC_DID)

--- a/poetry.lock
+++ b/poetry.lock
@@ -134,8 +134,8 @@ uvloop = ["uvloop"]
 [package.source]
 type = "git"
 url = "https://github.com/sicpa-dlab/aries-cloudagent-python"
-reference = "aae6d83d14c6eb0449b64c1b218947e738fd2f44"
-resolved_reference = "aae6d83d14c6eb0449b64c1b218947e738fd2f44"
+reference = "ea31bd78d17b0bc76cda11b85145c50f4258daa4"
+resolved_reference = "ea31bd78d17b0bc76cda11b85145c50f4258daa4"
 
 [[package]]
 name = "async-timeout"
@@ -199,6 +199,14 @@ python-versions = "*"
 pycparser = "*"
 
 [[package]]
+name = "cfgv"
+version = "3.3.1"
+description = "Validate configuration and produce human readable error messages."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[[package]]
 name = "chardet"
 version = "4.0.0"
 description = "Universal encoding detector for Python 2 and 3"
@@ -254,6 +262,14 @@ optional = false
 python-versions = ">=3"
 
 [[package]]
+name = "distlib"
+version = "0.3.6"
+description = "Distribution utilities"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.1"
 description = "ECDSA cryptographic signature library (pure python)"
@@ -267,6 +283,18 @@ six = ">=1.9.0"
 [package.extras]
 gmpy = ["gmpy"]
 gmpy2 = ["gmpy2"]
+
+[[package]]
+name = "filelock"
+version = "3.9.0"
+description = "A platform independent file lock."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2022.12.7)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
+testing = ["covdefaults (>=2.2.2)", "coverage (>=7.0.1)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "frozendict"
@@ -283,6 +311,17 @@ description = "A list-like structure which implements collections.abc.MutableSeq
 category = "main"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "identify"
+version = "2.5.13"
+description = "File identification library for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+license = ["ukkonen"]
 
 [[package]]
 name = "idna"
@@ -402,6 +441,17 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "nodeenv"
+version = "1.7.0"
+description = "Node.js virtual environment builder"
+category = "dev"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "packaging"
 version = "20.9"
 description = "Core utilities for Python packages"
@@ -425,12 +475,39 @@ docs = ["furo", "olefile", "sphinx (>=2.4)", "sphinx-copybutton", "sphinx-inline
 tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
 
 [[package]]
+name = "platformdirs"
+version = "2.6.2"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+
+[[package]]
 name = "ply"
 version = "3.11"
 description = "Python Lex & Yacc"
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "pre-commit"
+version = "2.21.0"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
+virtualenv = ">=20.10.0"
 
 [[package]]
 name = "prompt-toolkit"
@@ -613,7 +690,7 @@ python-versions = "*"
 
 [[package]]
 name = "setuptools"
-version = "65.7.0"
+version = "66.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
@@ -670,8 +747,25 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "p
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "virtualenv"
+version = "20.17.1"
+description = "Virtual Python Environment builder"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+distlib = ">=0.3.6,<1"
+filelock = ">=3.4.1,<4"
+platformdirs = ">=2.4,<3"
+
+[package.extras]
+docs = ["proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-argparse (>=0.3.2)", "sphinx-rtd-theme (>=1)", "towncrier (>=22.8)"]
+testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
+
+[[package]]
 name = "wcwidth"
-version = "0.2.5"
+version = "0.2.6"
 description = "Measures the displayed width of unicode strings in a terminal"
 category = "main"
 optional = false
@@ -711,7 +805,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.11"
-content-hash = "a60e7633a9a55d0a301c067b7f8ce317779afab2f40f84ca526102cbb7594ebb"
+content-hash = "8f7ca2748f4ef8df3e74d57517baa36de86331e3a6dbbaec3e0945fe2fa89a96"
 
 [metadata.files]
 aiohttp = [
@@ -909,6 +1003,10 @@ cffi = [
     {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
     {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
 ]
+cfgv = [
+    {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
+    {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
+]
 chardet = [
     {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
     {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
@@ -933,9 +1031,17 @@ deepmerge = [
     {file = "deepmerge-0.3.0-py2.py3-none-any.whl", hash = "sha256:87166dbe9ba1a3348a45c9d4ada6778f518d41afc0b85aa017ea3041facc3f9c"},
     {file = "deepmerge-0.3.0.tar.gz", hash = "sha256:f6fd7f1293c535fb599e197e750dbe8674503c5d2a89759b3c72a3c46746d4fd"},
 ]
+distlib = [
+    {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
+    {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
+]
 ecdsa = [
     {file = "ecdsa-0.16.1-py2.py3-none-any.whl", hash = "sha256:881fa5e12bb992972d3d1b3d4dfbe149ab76a89f13da02daa5ea1ec7dea6e747"},
     {file = "ecdsa-0.16.1.tar.gz", hash = "sha256:cfc046a2ddd425adbd1a78b3c46f0d1325c657811c0f45ecc3a0a6236c1e50ff"},
+]
+filelock = [
+    {file = "filelock-3.9.0-py3-none-any.whl", hash = "sha256:f58d535af89bb9ad5cd4df046f741f8553a418c01a7856bf0d173bbc9f6bd16d"},
+    {file = "filelock-3.9.0.tar.gz", hash = "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de"},
 ]
 frozendict = [
     {file = "frozendict-2.3.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4a3b32d47282ae0098b9239a6d53ec539da720258bd762d62191b46f2f87c5fc"},
@@ -1031,6 +1137,10 @@ frozenlist = [
     {file = "frozenlist-1.3.3-cp39-cp39-win32.whl", hash = "sha256:efa568b885bca461f7c7b9e032655c0c143d305bf01c30caf6db2854a4532b38"},
     {file = "frozenlist-1.3.3-cp39-cp39-win_amd64.whl", hash = "sha256:cfe33efc9cb900a4c46f91a5ceba26d6df370ffddd9ca386eb1d4f0ad97b9ea9"},
     {file = "frozenlist-1.3.3.tar.gz", hash = "sha256:58bcc55721e8a90b88332d6cd441261ebb22342e238296bb330968952fbb3a6a"},
+]
+identify = [
+    {file = "identify-2.5.13-py2.py3-none-any.whl", hash = "sha256:8aa48ce56e38c28b6faa9f261075dea0a942dfbb42b341b4e711896cbb40f3f7"},
+    {file = "identify-2.5.13.tar.gz", hash = "sha256:abb546bca6f470228785338a01b539de8a85bbf46491250ae03363956d8ebb10"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -1338,6 +1448,10 @@ nest-asyncio = [
     {file = "nest_asyncio-1.5.6-py3-none-any.whl", hash = "sha256:b9a953fb40dceaa587d109609098db21900182b16440652454a146cffb06e8b8"},
     {file = "nest_asyncio-1.5.6.tar.gz", hash = "sha256:d267cc1ff794403f7df692964d1d2a3fa9418ffea2a3f6859a439ff482fef290"},
 ]
+nodeenv = [
+    {file = "nodeenv-1.7.0-py2.py3-none-any.whl", hash = "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e"},
+    {file = "nodeenv-1.7.0.tar.gz", hash = "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"},
+]
 packaging = [
     {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
     {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
@@ -1407,9 +1521,17 @@ pillow = [
     {file = "Pillow-9.4.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:8f127e7b028900421cad64f51f75c051b628db17fb00e099eb148761eed598c9"},
     {file = "Pillow-9.4.0.tar.gz", hash = "sha256:a1c2d7780448eb93fbcc3789bf3916aa5720d942e37945f4056680317f1cd23e"},
 ]
+platformdirs = [
+    {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
+    {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
+]
 ply = [
     {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
     {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
+]
+pre-commit = [
+    {file = "pre_commit-2.21.0-py2.py3-none-any.whl", hash = "sha256:e2f91727039fc39a92f58a588a25b87f936de6567eed4f0e673e0507edc75bad"},
+    {file = "pre_commit-2.21.0.tar.gz", hash = "sha256:31ef31af7e474a8d8995027fefdfcf509b5c913ff31f2015b4ec4beb26a6f658"},
 ]
 prompt-toolkit = [
     {file = "prompt_toolkit-2.0.10-py2-none-any.whl", hash = "sha256:e7f8af9e3d70f514373bf41aa51bc33af12a6db3f71461ea47fea985defb2c31"},
@@ -1536,8 +1658,8 @@ rlp = [
     {file = "rlp-0.5.1.tar.gz", hash = "sha256:a14ae51b1b04e28de5cbc9edcdc4830904c1b94f5712ef57a8d9852b69607d97"},
 ]
 setuptools = [
-    {file = "setuptools-65.7.0-py3-none-any.whl", hash = "sha256:8ab4f1dbf2b4a65f7eec5ad0c620e84c34111a68d3349833494b9088212214dd"},
-    {file = "setuptools-65.7.0.tar.gz", hash = "sha256:4d3c92fac8f1118bb77a22181355e29c239cabfe2b9effdaa665c66b711136d7"},
+    {file = "setuptools-66.0.0-py3-none-any.whl", hash = "sha256:a78d01d1e2c175c474884671dde039962c9d74c7223db7369771fcf6e29ceeab"},
+    {file = "setuptools-66.0.0.tar.gz", hash = "sha256:bd6eb2d6722568de6d14b87c44a96fac54b2a45ff5e940e639979a3d1792adb6"},
 ]
 simplejson = [
     {file = "simplejson-3.18.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:e153cd584d63aa9c70db25b7c094e15ec2dae804ab78291a1a8709be768dcaa2"},
@@ -1629,9 +1751,13 @@ urllib3 = [
     {file = "urllib3-1.26.14-py2.py3-none-any.whl", hash = "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"},
     {file = "urllib3-1.26.14.tar.gz", hash = "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72"},
 ]
+virtualenv = [
+    {file = "virtualenv-20.17.1-py3-none-any.whl", hash = "sha256:ce3b1684d6e1a20a3e5ed36795a97dfc6af29bc3970ca8dab93e11ac6094b3c4"},
+    {file = "virtualenv-20.17.1.tar.gz", hash = "sha256:f8b927684efc6f1cc206c9db297a570ab9ad0e51c16fa9e45487d36d1905c058"},
+]
 wcwidth = [
-    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
-    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+    {file = "wcwidth-0.2.6-py2.py3-none-any.whl", hash = "sha256:795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e"},
+    {file = "wcwidth-0.2.6.tar.gz", hash = "sha256:a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0"},
 ]
 webargs = [
     {file = "webargs-5.5.3-py2-none-any.whl", hash = "sha256:fc81c9f9d391acfbce406a319217319fd8b2fd862f7fdb5319ad06944f36ed25"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,11 @@ packages = [{include = "didweb"}]
 [tool.poetry.dependencies]
 python = "^3.11"
 #aries-cloudagent = "^1.0.0-rc1"
-aries-cloudagent = { git = "https://github.com/sicpa-dlab/aries-cloudagent-python", rev = "aae6d83d14c6eb0449b64c1b218947e738fd2f44"}
+aries-cloudagent = { git = "https://github.com/sicpa-dlab/aries-cloudagent-python", rev = "ea31bd78d17b0bc76cda11b85145c50f4258daa4"}
 
+
+[tool.poetry.group.dev.dependencies]
+pre-commit = "^2.21.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
* Add `StoragePolicy` to store previous keys
* Add `RecallPolicy` to configure how many keys to recall and how
* Provide a parameter to retrieve a diddoc with a given number of keys

Also:

* Add pre-commit with `flake8` and `black`.
* Add a few readme lines on development

Notes: 
* Having a time-based policy for key retention might be tricky: the initial key created by aca-py out of our control is not marked with any kind of timestamp.
* Missing some doc on elements that have a high chance to chang
* Same remark for tests