### PR TITLE
feat: route registration

### DIFF
--- a/didweb/route_registration.py
+++ b/didweb/route_registration.py
@@ -1,0 +1,23 @@
+from aries_cloudagent.protocols.routing.v1_0.manager import RoutingManager
+from aries_cloudagent.protocols.routing.v1_0.models.route_record import RouteRecord
+from aries_cloudagent.wallet.base import BaseWallet
+
+
+class RouteRegistrar:
+    """No route ? No worries."""
+
+    def __init__(self, wallet: BaseWallet, routing_manager: RoutingManager):
+        self.__wallet = wallet
+        self.__routing_manager = routing_manager
+
+    async def register_route(self, did: str, wallet_id: str) -> RouteRecord:
+        """
+        Register a route given a did and a recipient wallet
+        :param did: DID on the receiving end of the route
+        :param wallet_id: wallet on the receiving end of the route
+        :return:
+        """
+        did_record = await self.__wallet.get_local_did(did)
+        return await self.__routing_manager.create_route_record(
+            recipient_key=did_record.verkey, internal_wallet_id=wallet_id
+        )

--- a/didweb/routes/__init__.py
+++ b/didweb/routes/__init__.py
@@ -1,4 +1,6 @@
 from aiohttp import web
+
+from .register_route import register_route
 from .get_diddoc import fetch_diddoc
 from .rotate_key import rotate_key
 
@@ -11,6 +13,7 @@ async def register(app: web.Application):
         [
             web.get("/didweb/diddoc", fetch_diddoc),
             web.put("/didweb/rotate", rotate_key),
+            web.put("/routing/register_route", register_route),
         ]
     )
 

--- a/didweb/routes/register_route.py
+++ b/didweb/routes/register_route.py
@@ -1,0 +1,44 @@
+from aiohttp import web
+from aiohttp_apispec import querystring_schema, response_schema
+from aiohttp_apispec.decorators import docs
+from aries_cloudagent.admin.request_context import AdminRequestContext
+from aries_cloudagent.protocols.routing.v1_0.manager import RoutingManager
+from aries_cloudagent.protocols.routing.v1_0.models.route_record import RouteRecordSchema
+from aries_cloudagent.wallet.base import BaseWallet
+
+from ..route_registration import RouteRegistrar
+from .openapi_config import OPENAPI_TAG
+from .schemas import DIDSchema
+
+
+@docs(
+    tags=[OPENAPI_TAG],
+    summary="Registers a route for a given DID within a multi-tenanted agent.",
+)
+@querystring_schema(DIDSchema())
+@response_schema(RouteRecordSchema())
+async def register_route(request: web.Request):
+    did = request.query.get("did")
+    if not did:
+        raise web.HTTPBadRequest(reason="Request query must include DID")
+
+    context: AdminRequestContext = request["context"]
+
+    print(context.profile.settings)
+    try:
+        wallet_id = context.profile.settings["wallet.id"]
+    except KeyError:
+        return web.Response(
+            status=404,
+            text="Registering routes is not necessary for single-tenant agents.",
+        )
+
+    async with context.profile.transaction() as transaction:
+        route_registrar = RouteRegistrar(
+            transaction.inject(BaseWallet), RoutingManager(context.profile)
+        )
+        route_record = await route_registrar.register_route(did, wallet_id)
+
+        await transaction.commit()
+
+    return web.Response(text=RouteRecordSchema().dumps(route_record))

--- a/didweb/routes/rotate_key.py
+++ b/didweb/routes/rotate_key.py
@@ -8,11 +8,11 @@ from aries_cloudagent.wallet.base import BaseWallet
 
 from ..didweb_manager import DIDWebManager
 from .openapi_config import OPENAPI_TAG
-from .schemas import DIDDocSchema, DIDWebSchema
+from .schemas import DIDDocSchema, DIDSchema
 
 
 @docs(tags=[OPENAPI_TAG], summary="Rotate keys for specified did:web, return new DIDDoc")
-@querystring_schema(DIDWebSchema())
+@querystring_schema(DIDSchema())
 @response_schema(DIDDocSchema())
 async def rotate_key(request: web.Request):
     did = request.query.get("did")

--- a/didweb/routes/schemas.py
+++ b/didweb/routes/schemas.py
@@ -30,7 +30,7 @@ class KeyRetentionConfigSchema(OpenAPISchema):
     number_of_keys = fields.Int(required=True)
 
 
-class DIDWebSchema(OpenAPISchema):
+class DIDSchema(OpenAPISchema):
     """ """
 
     did = fields.Str(required=True, **GENERIC_DID)


### PR DESCRIPTION
When using multi-tenant mode, ACA-Py uses a routing table mapping recipient key to the recipient wallet.

Routes are created when invitations are created. 

If a third-party builds an invitation from a public DID Document (so-called "implicit invitation"), the verification key referenced in the DIDComm service needs to be registered in the routing table.

This commit adds an endpoint to allow registering the verification key of a DID in the routing table.

Note: I'm adding this in this plugin for speed but we might want to revise the content of the plugin and rename the plugin or split it in multiple ones.