### PR TITLE
chore: move endpoints to "wallet" openapi group

### DIFF
--- a/didweb/routes/__init__.py
+++ b/didweb/routes/__init__.py
@@ -5,34 +5,17 @@ from .register_route import register_route
 from .get_diddoc import fetch_diddoc
 from .rotate_key import rotate_key
 
-from .openapi_config import SPEC_URI, OPENAPI_TAG
-
 
 async def register(app: web.Application):
     """Register routes."""
     app.add_routes(
         [
-            web.get("/didweb/diddoc", fetch_diddoc),
-            web.put("/didweb/rotate", rotate_key),
-            web.put("/routing/register_route", register_route),
-            web.put("/routing/set_public_did", set_public_did),
+            web.get("/wallet/{did}/diddoc", fetch_diddoc, allow_head=False),
+            web.put("/wallet/{did}/rotate-keys", rotate_key),
+            web.put("/wallet/{did}/routing/register-route", register_route),
+            web.put("/wallet/{did}/mark-public", set_public_did),
         ]
     )
 
 
-def post_process_routes(app: web.Application):
-    """Amend swagger API."""
-    # Add top-level tags description
-    if "tags" not in app._state["swagger_dict"]:
-        app._state["swagger_dict"]["tags"] = []
-
-    app._state["swagger_dict"]["tags"].append(
-        {
-            "name": OPENAPI_TAG,
-            "description": "did:web management",
-            "externalDocs": {"description": "Specification", "url": SPEC_URI},
-        }
-    )
-
-
-__all__ = ["register", "post_process_routes"]
+__all__ = ["register"]

--- a/didweb/routes/get_diddoc.py
+++ b/didweb/routes/get_diddoc.py
@@ -1,5 +1,5 @@
 from aiohttp import web
-from aiohttp_apispec import querystring_schema, response_schema
+from aiohttp_apispec import querystring_schema, response_schema, match_info_schema
 from aiohttp_apispec.decorators import docs
 from aries_cloudagent.admin.request_context import AdminRequestContext
 from aries_cloudagent.storage.base import BaseStorage
@@ -7,15 +7,17 @@ from aries_cloudagent.wallet.base import BaseWallet
 
 from ..didweb_manager import DIDWebManager
 from .openapi_config import OPENAPI_TAG
-from .schemas import GetDIDDocSchema, DIDDocSchema
+from .schemas import GetDIDDocSchema, DIDDocSchema, DIDSchema
 from ..retention import RecallStrategyConfig
 
 
-@docs(tags=[OPENAPI_TAG], summary="Gets DIDDoc for specified did:web")
+@docs(tags=[OPENAPI_TAG], summary="Gets DIDDoc for specified did")
+@match_info_schema(DIDSchema())
 @querystring_schema(GetDIDDocSchema())
 @response_schema(DIDDocSchema())
 async def fetch_diddoc(request: web.Request):
-    did = request.query.get("did")
+    did = request.match_info.get("did")
+    print(did)
     if not did:
         raise web.HTTPBadRequest(reason="Request query must include DID")
     number_of_keys = int(request.query.get("number_of_keys", "1"))

--- a/didweb/routes/mark_did_public.py
+++ b/didweb/routes/mark_did_public.py
@@ -1,5 +1,5 @@
 from aiohttp import web
-from aiohttp_apispec import docs, querystring_schema
+from aiohttp_apispec import docs, match_info_schema
 from aries_cloudagent.admin.request_context import AdminRequestContext
 from aries_cloudagent.wallet.base import BaseWallet
 from aries_cloudagent.wallet.did_posture import DIDPosture
@@ -13,7 +13,7 @@ from didweb.routes.schemas import DIDSchema
     summary="Set public DID of the wallet."
     "This is limited to the wallet, no ledger interaction.",
 )
-@querystring_schema(DIDSchema())
+@match_info_schema(DIDSchema())
 async def set_public_did(request: web.Request):
     did = request.query.get("did")
     if not did:

--- a/didweb/routes/openapi_config.py
+++ b/didweb/routes/openapi_config.py
@@ -1,2 +1,1 @@
-SPEC_URI = ("https://w3c-ccg.github.io/did-method-web",)
-OPENAPI_TAG = "did-web"
+OPENAPI_TAG = "wallet"

--- a/didweb/routes/register_route.py
+++ b/didweb/routes/register_route.py
@@ -1,5 +1,5 @@
 from aiohttp import web
-from aiohttp_apispec import querystring_schema
+from aiohttp_apispec import match_info_schema
 from aiohttp_apispec.decorators import docs
 from aries_cloudagent.admin.request_context import AdminRequestContext
 from aries_cloudagent.protocols.coordinate_mediation.v1_0.route_manager import (
@@ -17,7 +17,7 @@ from .schemas import DIDSchema
     summary="Registers a route for a given DID within a multi-tenanted agent.",
     responses={201: {"description": "Route registered."}},
 )
-@querystring_schema(DIDSchema())
+@match_info_schema(DIDSchema())
 async def register_route(request: web.Request):
     did = request.query.get("did")
     if not did:

--- a/didweb/routes/rotate_key.py
+++ b/didweb/routes/rotate_key.py
@@ -1,5 +1,5 @@
 from aiohttp import web
-from aiohttp_apispec import querystring_schema, response_schema
+from aiohttp_apispec import response_schema, match_info_schema
 from aiohttp_apispec.decorators import docs
 
 from aries_cloudagent.admin.request_context import AdminRequestContext
@@ -11,8 +11,8 @@ from .openapi_config import OPENAPI_TAG
 from .schemas import DIDDocSchema, DIDSchema
 
 
-@docs(tags=[OPENAPI_TAG], summary="Rotate keys for specified did:web, return new DIDDoc")
-@querystring_schema(DIDSchema())
+@docs(tags=[OPENAPI_TAG], summary="Rotate keys for specified did, returns new DIDDoc")
+@match_info_schema(DIDSchema())
 @response_schema(DIDDocSchema())
 async def rotate_key(request: web.Request):
     did = request.query.get("did")

--- a/didweb/routes/schemas.py
+++ b/didweb/routes/schemas.py
@@ -37,7 +37,6 @@ class DIDSchema(OpenAPISchema):
 
 
 class GetDIDDocSchema(OpenAPISchema):
-    did = fields.Str(required=True, **GENERIC_DID)
     number_of_keys = fields.Int(required=False)
 
 


### PR DESCRIPTION
This makes more sense since none of these endpoints are did-web related. I wanted to change that before having code referring to "did-web" in other components.

Also:
* rework routes to include did in url
* remove HEAD endpoint for get_diddoc